### PR TITLE
Move players related HandState methods to separate List<Player> extensions

### DIFF
--- a/server/src/main/kotlin/core/bettinground/BettingAction.kt
+++ b/server/src/main/kotlin/core/bettinground/BettingAction.kt
@@ -1,7 +1,8 @@
 package core.bettinground
 import core.gameflow.handstate.HandState
-import core.gameflow.handstate.nextDecisivePlayer
 import core.gameflow.handstate.rebuild
+import core.gameflow.player.inGame
+import core.gameflow.player.nextDecisive
 
 abstract class BettingAction(val type: ActionType) {
 
@@ -29,14 +30,14 @@ abstract class BettingAction(val type: ActionType) {
     private fun shiftActivePlayer(handState: HandState): HandState {
 
         handState.activePlayer!!
-        val nextDecisivePlayer = handState.nextDecisivePlayer(handState.activePlayer)
+        val nextDecisivePlayer = handState.players.nextDecisive(handState.activePlayer)
 
         return when {
             /* End action when there are no more decisive players. */
             nextDecisivePlayer == null -> handState.rebuild(activePlayer = null)
 
             /* End action when only one player is left in the hand. */
-            handState.playersInGame.size == 1 -> handState.rebuild(activePlayer = null)
+            handState.players.inGame().size == 1 -> handState.rebuild(activePlayer = null)
 
             /* End action when current action taker is the last decisive player in the hand. */
             nextDecisivePlayer == handState.activePlayer -> handState.rebuild(activePlayer = null)

--- a/server/src/main/kotlin/core/gameflow/handstate/HandState.kt
+++ b/server/src/main/kotlin/core/gameflow/handstate/HandState.kt
@@ -3,8 +3,9 @@ package core.gameflow.handstate
 import core.cards.Card
 import core.gameflow.BettingRound
 import core.gameflow.Blinds
-import core.gameflow.Player
+import core.gameflow.player.Player
 import core.gameflow.Positions
+import core.gameflow.player.getByPosition
 
 /**
  * activePlayer set to null indicates that there is no further action possible in given betting round.
@@ -34,16 +35,11 @@ class HandState private constructor(
     val pot: Int = players.sumBy { it.chipsInPot }
     val totalBet: Int = lastLegalBet + extraBet
 
-    val playersInGame: List<Player> = players.filter { it.isInGame }
-    val decisivePlayers: List<Player> = players.filter { it.isDecisive }
-
-    fun playerAtPosition(position: Int): Player? = players.find { it.position == position }
-
     // Small blind position sometimes may point to an empty when players leave the table between hands.
-    val smallBlindPlayer: Player? = playerAtPosition(positions.smallBlind)
+    val smallBlindPlayer: Player? = players.getByPosition(positions.smallBlind)
 
     // Big blind position must always point to some player.
-    val bigBlindPlayer: Player = playerAtPosition(positions.bigBlind)!!
+    val bigBlindPlayer: Player = players.getByPosition(positions.bigBlind)!!
 
     data class ImmutableBuilder(
         val players: List<Player>? = null,

--- a/server/src/main/kotlin/core/gameflow/handstate/HandStateExtensions.kt
+++ b/server/src/main/kotlin/core/gameflow/handstate/HandStateExtensions.kt
@@ -3,24 +3,8 @@ package core.gameflow.handstate
 import core.cards.Card
 import core.gameflow.BettingRound
 import core.gameflow.Blinds
-import core.gameflow.Player
+import core.gameflow.player.Player
 import core.gameflow.Positions
-
-/* Utility methods for manipulating players: */
-
-fun HandState.orderedPlayers(startingPosition: Int): List<Player> {
-    val sortedPlayers = players.sortedBy { it.position }
-    val begin = sortedPlayers.filter { it.position >= startingPosition }
-    val end = sortedPlayers.filter { it.position < startingPosition }
-    return begin + end
-}
-
-fun HandState.nextPlayer(position: Int): Player = orderedPlayers(position + 1).first()
-fun HandState.nextPlayer(player: Player): Player = nextPlayer(player.position)
-
-fun HandState.nextDecisivePlayer(position: Int): Player? =
-        orderedPlayers(position + 1).find { it.isDecisive }
-fun HandState.nextDecisivePlayer(player: Player): Player? = nextDecisivePlayer(player.position)
 
 fun HandState.updateActivePlayer(playerUpdate: Player): HandState {
 

--- a/server/src/main/kotlin/core/gameflow/player/Player.kt
+++ b/server/src/main/kotlin/core/gameflow/player/Player.kt
@@ -1,4 +1,4 @@
-package core.gameflow
+package core.gameflow.player
 
 import core.cards.Card
 import core.bettinground.ActionType

--- a/server/src/main/kotlin/core/gameflow/player/PlayersListExtensions.kt
+++ b/server/src/main/kotlin/core/gameflow/player/PlayersListExtensions.kt
@@ -1,0 +1,19 @@
+package core.gameflow.player
+
+fun List<Player>.ordered(startingPosition: Int): List<Player> {
+    val sortedPlayers = sortedBy { it.position }
+    val begin = sortedPlayers.filter { it.position >= startingPosition }
+    val end = sortedPlayers.filter { it.position < startingPosition }
+    return begin + end
+}
+
+fun List<Player>.next(from: Int): Player = ordered(from + 1).first()
+fun List<Player>.next(from: Player): Player = next(from.position)
+
+fun List<Player>.nextDecisive(from: Int): Player? = ordered(from + 1).find { it.isDecisive }
+fun List<Player>.nextDecisive(from: Player): Player? = nextDecisive(from.position)
+
+fun List<Player>.inGame(): List<Player> = this.filter { it.isInGame }
+fun List<Player>.decisive(): List<Player> = this.filter { it.isDecisive }
+
+fun List<Player>.getByPosition(position: Int): Player? = this.find { it.position == position }

--- a/server/src/main/kotlin/core/gameflow/showdown.kt
+++ b/server/src/main/kotlin/core/gameflow/showdown.kt
@@ -1,7 +1,8 @@
 package core.gameflow
 
 import core.gameflow.handstate.HandState
-import core.gameflow.handstate.orderedPlayers
+import core.gameflow.player.Player
+import core.gameflow.player.ordered
 
 sealed class ShowdownAction {
     abstract val playerId: Int
@@ -13,8 +14,8 @@ data class MuckCards(override val playerId: Int) : ShowdownAction()
 fun resolveShowdown(handState: HandState): List<ShowdownAction> {
 
     val orderedPlayers = when {
-        handState.lastAggressor == null -> handState.orderedPlayers(handState.positions.button + 1)
-        else -> handState.orderedPlayers(handState.lastAggressor.position)
+        handState.lastAggressor == null -> handState.players.ordered(handState.positions.button + 1)
+        else -> handState.players.ordered(handState.lastAggressor.position)
     }.filter { it.isInGame }
 
     // Player can muck his cards if he is the only one left in the hand.

--- a/server/src/test/kotlin/core/bettinground/AllInTest.kt
+++ b/server/src/test/kotlin/core/bettinground/AllInTest.kt
@@ -2,7 +2,7 @@ package core.bettinground
 
 import core.gameflow.Blinds
 import core.gameflow.handstate.HandState
-import core.gameflow.Player
+import core.gameflow.player.Player
 import core.gameflow.Positions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance

--- a/server/src/test/kotlin/core/bettinground/BetTest.kt
+++ b/server/src/test/kotlin/core/bettinground/BetTest.kt
@@ -2,6 +2,7 @@ package core.bettinground
 
 import core.gameflow.*
 import core.gameflow.handstate.HandState
+import core.gameflow.player.Player
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 

--- a/server/src/test/kotlin/core/bettinground/CallTest.kt
+++ b/server/src/test/kotlin/core/bettinground/CallTest.kt
@@ -2,6 +2,7 @@ package core.bettinground
 
 import core.gameflow.*
 import core.gameflow.handstate.HandState
+import core.gameflow.player.Player
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 

--- a/server/src/test/kotlin/core/bettinground/CheckTest.kt
+++ b/server/src/test/kotlin/core/bettinground/CheckTest.kt
@@ -2,6 +2,7 @@ package core.bettinground
 
 import core.gameflow.*
 import core.gameflow.handstate.HandState
+import core.gameflow.player.Player
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 

--- a/server/src/test/kotlin/core/bettinground/FoldTest.kt
+++ b/server/src/test/kotlin/core/bettinground/FoldTest.kt
@@ -2,6 +2,8 @@ package core.bettinground
 
 import core.gameflow.*
 import core.gameflow.handstate.HandState
+import core.gameflow.player.Player
+import core.gameflow.player.inGame
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
@@ -28,7 +30,7 @@ class FoldTest {
         val newState = fold.apply(state)
 
         assert(newState.activePlayer == player2)
-        assert(newState.playersInGame.toSet() == setOf(player0, player2))
+        assert(newState.players.inGame().toSet() == setOf(player0, player2))
     }
 
     @Test
@@ -51,7 +53,7 @@ class FoldTest {
         val newState = fold.apply(state)
 
         assert(newState.activePlayer == null)
-        assert(newState.playersInGame.toSet() == setOf(player0, player2))
+        assert(newState.players.inGame().toSet() == setOf(player0, player2))
     }
 
     @Test
@@ -74,7 +76,7 @@ class FoldTest {
         val newState = fold.apply(state)
 
         assert(newState.activePlayer == null)
-        assert(newState.playersInGame.toSet() == setOf(player3))
+        assert(newState.players.inGame().toSet() == setOf(player3))
     }
 
     @Test
@@ -97,7 +99,7 @@ class FoldTest {
         val newState = fold.apply(state)
 
         assert(newState.activePlayer == player3)
-        assert(newState.playersInGame.toSet() == setOf(player1, player3))
+        assert(newState.players.inGame().toSet() == setOf(player1, player3))
     }
 
     @Test
@@ -120,6 +122,6 @@ class FoldTest {
         val newState = fold.apply(state)
 
         assert(newState.activePlayer == null)
-        assert(newState.playersInGame.toSet() == setOf(player1, player3))
+        assert(newState.players.inGame().toSet() == setOf(player1, player3))
     }
 }

--- a/server/src/test/kotlin/core/bettinground/PostTest.kt
+++ b/server/src/test/kotlin/core/bettinground/PostTest.kt
@@ -2,6 +2,7 @@ package core.bettinground
 
 import core.gameflow.*
 import core.gameflow.handstate.HandState
+import core.gameflow.player.Player
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 

--- a/server/src/test/kotlin/core/bettinground/RaiseTest.kt
+++ b/server/src/test/kotlin/core/bettinground/RaiseTest.kt
@@ -2,7 +2,7 @@ package core.bettinground
 
 import core.gameflow.Blinds
 import core.gameflow.handstate.HandState
-import core.gameflow.Player
+import core.gameflow.player.Player
 import core.gameflow.Positions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance

--- a/server/src/test/kotlin/core/gameflow/DealerTest.kt
+++ b/server/src/test/kotlin/core/gameflow/DealerTest.kt
@@ -5,6 +5,7 @@ import core.cards.CardSuit
 import core.cards.baseDeck
 import core.gameflow.handstate.HandState
 import core.gameflow.handstate.rebuild
+import core.gameflow.player.Player
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows

--- a/server/src/test/kotlin/core/gameflow/ShowdownTest.kt
+++ b/server/src/test/kotlin/core/gameflow/ShowdownTest.kt
@@ -5,6 +5,7 @@ import core.cards.CardRank
 import core.cards.CardSuit
 import core.bettinground.ActionType
 import core.gameflow.handstate.HandState
+import core.gameflow.player.Player
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 

--- a/server/src/test/kotlin/core/gameflow/handstate/HandStateExtensionsTest.kt
+++ b/server/src/test/kotlin/core/gameflow/handstate/HandStateExtensionsTest.kt
@@ -2,53 +2,13 @@ package core.gameflow.handstate
 
 import core.bettinground.ActionType
 import core.gameflow.Blinds
-import core.gameflow.Player
+import core.gameflow.player.Player
 import core.gameflow.Positions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HandStateExtensionsTest {
-
-    @Test
-    fun `playersInGame should find all players that haven't folded yet`() {
-
-        val player0 = Player(position = 0, stack = 0, lastAction = ActionType.ALL_IN)
-        val player1 = Player(position = 1, stack = 100, lastAction = ActionType.FOLD)
-        val player2 = Player(position = 2, stack = 100)
-        val player3 = Player(position = 3, stack = 100)
-
-        val state = HandState.ImmutableBuilder(
-                players = listOf(player0, player1, player2, player3),
-                blinds = Blinds(50, 100),
-                positions = Positions(button = 0, smallBlind = 1, bigBlind = 2),
-                activePlayer = player2,
-                lastLegalBet = 100,
-                extraBet = 75
-        ).build()
-
-        assert(state.playersInGame == listOf(player0, player2, player3))
-    }
-
-    @Test
-    fun `decisivePlayers should find all players that can potentially make decisions`() {
-
-        val player0 = Player(position = 0, stack = 0, lastAction = ActionType.ALL_IN)
-        val player1 = Player(position = 1, stack = 100, lastAction = ActionType.FOLD)
-        val player2 = Player(position = 2, stack = 100)
-        val player3 = Player(position = 3, stack = 100)
-
-        val state = HandState.ImmutableBuilder(
-                players = listOf(player0, player1, player2, player3),
-                blinds = Blinds(50, 100),
-                positions = Positions(button = 0, smallBlind = 1, bigBlind = 2),
-                activePlayer = player2,
-                lastLegalBet = 100,
-                extraBet = 75
-        ).build()
-
-        assert(state.decisivePlayers == listOf(player2, player3))
-    }
 
     @Test
     fun `updateActivePlayer should properly substitute active player in players list`() {
@@ -69,62 +29,6 @@ class HandStateExtensionsTest {
         val newState = state.updateActivePlayer(newPlayer)
 
         assert(newState.players[3] == newPlayer)
-    }
-
-    @Test
-    fun `orderedPlayers should return players list in clockwise order`() {
-
-        val player0 = Player(position = 0, stack = 100)
-        val player1 = Player(position = 1, stack = 100)
-        val player2 = Player(position = 2, stack = 100)
-        val player3 = Player(position = 3, stack = 100)
-
-        val state = HandState.ImmutableBuilder(
-                players = listOf(player0, player1, player2, player3),
-                blinds = Blinds(50, 100),
-                positions = Positions(button = 0, smallBlind = 1, bigBlind = 2),
-                activePlayer = player3
-        ).build()
-
-        assert(state.orderedPlayers(2) == listOf(player2, player3, player0, player1))
-    }
-
-    @Test
-    fun `nextPlayer should find the first player after given position`() {
-
-        val player0 = Player(position = 0, stack = 100)
-        val player1 = Player(position = 1, stack = 100)
-        val player2 = Player(position = 2, stack = 100)
-        val player3 = Player(position = 3, stack = 100)
-
-        val state = HandState.ImmutableBuilder(
-                players = listOf(player0, player1, player2, player3),
-                blinds = Blinds(50, 100),
-                positions = Positions(button = 0, smallBlind = 1, bigBlind = 2),
-                activePlayer = player3
-        ).build()
-
-        assert(state.nextPlayer(0) == player1)
-        assert(state.nextPlayer(3) == player0)
-    }
-
-    @Test
-    fun `nextDecisivePlayer should find the first decisive player after given position`() {
-
-        val player0 = Player(position = 0, stack = 100)
-        val player1 = Player(position = 1, stack = 100, lastAction = ActionType.FOLD)
-        val player2 = Player(position = 2, stack = 100)
-        val player3 = Player(position = 3, stack = 0, lastAction = ActionType.ALL_IN)
-
-        val state = HandState.ImmutableBuilder(
-                players = listOf(player0, player1, player2, player3),
-                blinds = Blinds(50, 100),
-                positions = Positions(button = 0, smallBlind = 1, bigBlind = 2),
-                activePlayer = player3
-        ).build()
-
-        assert(state.nextDecisivePlayer(0) == player2)
-        assert(state.nextDecisivePlayer(3) == player0)
     }
 
     @Test

--- a/server/src/test/kotlin/core/gameflow/handstate/HandStateTest.kt
+++ b/server/src/test/kotlin/core/gameflow/handstate/HandStateTest.kt
@@ -1,7 +1,7 @@
 package core.gameflow.handstate
 
 import core.gameflow.Blinds
-import core.gameflow.Player
+import core.gameflow.player.Player
 import core.gameflow.Positions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -114,41 +114,5 @@ class HandStateTest {
 
         assert(state.smallBlindPlayer == player3)
         assert(state.bigBlindPlayer == player0)
-    }
-
-    @Test
-    fun `playerAtPosition should find player that the position points to`() {
-
-        val player0 = Player(position = 0, stack = 100)
-        val player1 = Player(position = 1, stack = 100)
-        val player2 = Player(position = 2, stack = 100)
-        val player3 = Player(position = 3, stack = 100)
-
-        val state = HandState.ImmutableBuilder(
-                players = listOf(player0, player1, player2, player3),
-                blinds = Blinds(50, 100),
-                positions = Positions(button = 0, smallBlind = 1, bigBlind = 2),
-                activePlayer = player3
-        ).build()
-
-        assert(state.playerAtPosition(0) == player0)
-        assert(state.playerAtPosition(3) == player3)
-    }
-
-    @Test
-    fun `playerAtPosition should return null if the position is empty`() {
-
-        val player0 = Player(position = 0, stack = 100)
-        val player1 = Player(position = 1, stack = 100)
-        val player3 = Player(position = 3, stack = 100)
-
-        val state = HandState.ImmutableBuilder(
-                players = listOf(player0, player1, player3),
-                blinds = Blinds(50, 100),
-                positions = Positions(button = 0, smallBlind = 1, bigBlind = 3),
-                activePlayer = player3
-        ).build()
-
-        assert(state.playerAtPosition(2) == null)
     }
 }

--- a/server/src/test/kotlin/core/gameflow/player/PlayerTest.kt
+++ b/server/src/test/kotlin/core/gameflow/player/PlayerTest.kt
@@ -1,4 +1,4 @@
-package core.gameflow
+package core.gameflow.player
 
 import core.cards.Card
 import core.cards.CardRank

--- a/server/src/test/kotlin/core/gameflow/player/PlayersListExtensionsTest.kt
+++ b/server/src/test/kotlin/core/gameflow/player/PlayersListExtensionsTest.kt
@@ -1,0 +1,102 @@
+package core.gameflow.player
+
+import core.bettinground.ActionType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PlayersListExtensionsTest {
+
+    @Test
+    fun `getByPosition should find player that the position points to`() {
+
+        val player0 = Player(position = 0, stack = 100)
+        val player1 = Player(position = 1, stack = 100)
+        val player2 = Player(position = 2, stack = 100)
+        val player3 = Player(position = 3, stack = 100)
+
+        val players = listOf(player0, player1, player2, player3)
+
+        assert(players.getByPosition(0) == player0)
+        assert(players.getByPosition(3) == player3)
+    }
+
+    @Test
+    fun `getByPosition should return null if the position is empty`() {
+
+        val player0 = Player(position = 0, stack = 100)
+        val player1 = Player(position = 1, stack = 100)
+        val player3 = Player(position = 3, stack = 100)
+
+        val players = listOf(player0, player1, player3)
+
+        assert(players.getByPosition(2) == null)
+    }
+
+    @Test
+    fun `ordered should return players list in clockwise order`() {
+
+        val player0 = Player(position = 0, stack = 100)
+        val player1 = Player(position = 1, stack = 100)
+        val player2 = Player(position = 2, stack = 100)
+        val player3 = Player(position = 3, stack = 100)
+
+        val players = listOf(player0, player1, player2, player3)
+
+        assert(players.ordered(2) == listOf(player2, player3, player0, player1))
+    }
+
+    @Test
+    fun `next should find the first player after given position`() {
+
+        val player0 = Player(position = 0, stack = 100)
+        val player1 = Player(position = 1, stack = 100)
+        val player2 = Player(position = 2, stack = 100)
+        val player3 = Player(position = 3, stack = 100)
+
+        val players = listOf(player0, player1, player2, player3)
+
+        assert(players.next(0) == player1)
+        assert(players.next(3) == player0)
+    }
+
+    @Test
+    fun `nextDecisive should find the first decisive player after given position`() {
+
+        val player0 = Player(position = 0, stack = 100)
+        val player1 = Player(position = 1, stack = 100, lastAction = ActionType.FOLD)
+        val player2 = Player(position = 2, stack = 100)
+        val player3 = Player(position = 3, stack = 0, lastAction = ActionType.ALL_IN)
+
+        val players = listOf(player0, player1, player2, player3)
+
+        assert(players.nextDecisive(0) == player2)
+        assert(players.nextDecisive(3) == player0)
+    }
+
+    @Test
+    fun `inGame should find all players that haven't folded yet`() {
+
+        val player0 = Player(position = 0, stack = 0, lastAction = ActionType.ALL_IN)
+        val player1 = Player(position = 1, stack = 100, lastAction = ActionType.FOLD)
+        val player2 = Player(position = 2, stack = 100)
+        val player3 = Player(position = 3, stack = 100)
+
+        val players = listOf(player0, player1, player2, player3)
+
+        assert(players.inGame() == listOf(player0, player2, player3))
+    }
+
+    @Test
+    fun `decisivePlayers should find all players that can potentially make decisions`() {
+
+        val player0 = Player(position = 0, stack = 0, lastAction = ActionType.ALL_IN)
+        val player1 = Player(position = 1, stack = 100, lastAction = ActionType.FOLD)
+        val player2 = Player(position = 2, stack = 100)
+        val player3 = Player(position = 3, stack = 100)
+
+        val players = listOf(player0, player1, player2, player3)
+
+        assert(players.decisive() == listOf(player2, player3))
+    }
+}


### PR DESCRIPTION
Proposition of extracting HandState methods that operate on players list to a separate file containing specifically list of players extension methods. This would make HandState code much cleaner and would properly delegate responsibility of searching for certain players to the extensions. It is also required to allow operating on lists of players from within HandState.ImmutableBuilder class.