### PR TITLE
Fix pot distribution

### DIFF
--- a/server/src/main/kotlin/core/gameflow/Pot.kt
+++ b/server/src/main/kotlin/core/gameflow/Pot.kt
@@ -29,7 +29,7 @@ fun HandState.pots(): List<Pot> {
         // bet among all in-game current pot contributors.
         // If player's committed chips amount is higher than this bet,
         // then the excess will be used to create another side pot.
-        val nextPotBetToCover = nextPotContributors.filter { it.isInGame }.map { it.chipsInPot }.min()!!
+        val nextPotBetToCover = nextPotPlayers.map { it.chipsInPot }.min()!!
 
         // Actual chips amount from each player that will form the next pot.
         // If a player is in game, his chunk will be equal to the difference between last and next pot bets.
@@ -57,8 +57,7 @@ fun resolvePot(handState: HandState): List<PotResult> {
         if (pot.players.size == 1) {
             val winner = pot.players.first()
             listOf(PotResult(pot.size, winner.id, pot.potNumber))
-        }
-        else {
+        } else {
             val bestHand = pot.players.map { it.hand(handState.communityCards) }.max()!!
             val potWinnersSet = pot.players.filter { it.hand(handState.communityCards).compareTo(bestHand) == 0 }.toSet()
 

--- a/server/src/main/kotlin/core/gameflow/Pot.kt
+++ b/server/src/main/kotlin/core/gameflow/Pot.kt
@@ -54,25 +54,31 @@ fun resolvePot(handState: HandState): List<PotResult> {
     val orderedPots = handState.pots().reversed()
 
     val potResults = orderedPots.map { pot ->
-        val bestHand = pot.players.map { it.hand(handState.communityCards) }.max()!!
-        val potWinnersSet = pot.players.filter { it.hand(handState.communityCards).compareTo(bestHand) == 0 }.toSet()
-
-        // if there are multiple winners, they should be awarded in betting order
-        val orderedPotWinners = handState.players
-                .ordered(handState.positions.button + 1)
-                .filter { it in potWinnersSet }
-
-        val chipsWon = pot.size / potWinnersSet.size
-
-        // If chips cannot be split equally, first players after the button are awarded with an extra chip
-        val extraChips = pot.size % potWinnersSet.size
-
-        val results = orderedPotWinners.mapIndexed { index, player ->
-            val chips = chipsWon + (if (index < extraChips) 1 else 0)
-            PotResult(chips, player.id, pot.potNumber)
+        if (pot.players.size == 1) {
+            val winner = pot.players.first()
+            listOf(PotResult(pot.size, winner.id, pot.potNumber))
         }
+        else {
+            val bestHand = pot.players.map { it.hand(handState.communityCards) }.max()!!
+            val potWinnersSet = pot.players.filter { it.hand(handState.communityCards).compareTo(bestHand) == 0 }.toSet()
 
-        results
+            // if there are multiple winners, they should be awarded in betting order
+            val orderedPotWinners = handState.players
+                    .ordered(handState.positions.button + 1)
+                    .filter { it in potWinnersSet }
+
+            val chipsWon = pot.size / potWinnersSet.size
+
+            // If chips cannot be split equally, first players after the button are awarded with an extra chip
+            val extraChips = pot.size % potWinnersSet.size
+
+            val results = orderedPotWinners.mapIndexed { index, player ->
+                val chips = chipsWon + (if (index < extraChips) 1 else 0)
+                PotResult(chips, player.id, pot.potNumber)
+            }
+
+            results
+        }
     }
 
     return potResults.reduce { acc, list -> acc + list }

--- a/server/src/test/kotlin/core/gameflow/PotTest.kt
+++ b/server/src/test/kotlin/core/gameflow/PotTest.kt
@@ -330,4 +330,39 @@ class PotTest {
             ))
         }
     }
+
+    @Test
+    fun `pot should be successfully resolved when there is only one player left in game and there are no community cards`() {
+        val player0 = Player(
+                position = 0, stack = 0,
+                chipsInPot = 100,
+                holeCards = listOf(Card(CardRank.KING, CardSuit.DIAMONDS), Card(CardRank.KING, CardSuit.CLUBS)),
+                lastAction = ActionType.ALL_IN
+        )
+
+        val player1 = Player(
+                position = 1, stack = 0,
+                chipsInPot = 10,
+                holeCards = listOf(Card(CardRank.QUEEN, CardSuit.HEARTS), Card(CardRank.JACK, CardSuit.HEARTS)),
+                lastAction = ActionType.FOLD
+        )
+
+        val player2 = Player(
+                position = 2, stack = 0,
+                chipsInPot = 20,
+                holeCards = listOf(Card(CardRank.ACE, CardSuit.CLUBS), Card(CardRank.JACK, CardSuit.CLUBS)),
+                lastAction = ActionType.FOLD
+        )
+
+        val state = baseBuilder.copy(
+                players = listOf(player0, player1, player2),
+                positions = Positions(0, 1, 2),
+                communityCards = emptyList()
+        ).build()
+
+        val potResults = resolvePot(state)
+        assert(potResults == listOf(
+                PotResult(130, player0.id, potNumber = 0) // player0 should win all chips
+        ))
+    }
 }


### PR DESCRIPTION
Bug appeared in scenarios with only one player left in game pre-flop. Pot distribution logic attempted to create the best hand for each player, but since everyone but one player folded pre-flop, there was no community cards, therefore an attempt to create player's hand resulted in an assertion error (at least 5 cards are necessary).